### PR TITLE
add CMS option for noindex SEO tag

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,10 +1,10 @@
-const _ = require('lodash')
-const path = require('path')
-const { createFilePath } = require('gatsby-source-filesystem')
-const { fmImagesToRelative } = require('gatsby-remark-relative-images')
+const _ = require("lodash");
+const path = require("path");
+const { createFilePath } = require("gatsby-source-filesystem");
+const { fmImagesToRelative } = require("gatsby-remark-relative-images");
 
 exports.createPages = ({ actions, graphql }) => {
-  const { createPage } = actions
+  const { createPage } = actions;
 
   return graphql(`
     {
@@ -25,14 +25,14 @@ exports.createPages = ({ actions, graphql }) => {
     }
   `).then((result) => {
     if (result.errors) {
-      result.errors.forEach((e) => console.error(e.toString()))
-      return Promise.reject(result.errors)
+      result.errors.forEach((e) => console.error(e.toString()));
+      return Promise.reject(result.errors);
     }
 
-    const posts = result.data.allMarkdownRemark.edges
+    const posts = result.data.allMarkdownRemark.edges;
 
     posts.forEach((edge) => {
-      const id = edge.node.id
+      const id = edge.node.id;
       createPage({
         path: edge.node.fields.slug,
         tags: edge.node.frontmatter.tags,
@@ -43,23 +43,23 @@ exports.createPages = ({ actions, graphql }) => {
         context: {
           id,
         },
-      })
-    })
+      });
+    });
 
     // Tag pages:
-    let tags = []
+    let tags = [];
     // Iterate through each post, putting all found tags into `tags`
     posts.forEach((edge) => {
       if (_.get(edge, `node.frontmatter.tags`)) {
-        tags = tags.concat(edge.node.frontmatter.tags)
+        tags = tags.concat(edge.node.frontmatter.tags);
       }
-    })
+    });
     // Eliminate duplicate tags
-    tags = _.uniq(tags)
+    tags = _.uniq(tags);
 
     // Make tag pages
     tags.forEach((tag) => {
-      const tagPath = `/tags/${_.kebabCase(tag)}/`
+      const tagPath = `/tags/${_.kebabCase(tag)}/`;
 
       createPage({
         path: tagPath,
@@ -67,24 +67,24 @@ exports.createPages = ({ actions, graphql }) => {
         context: {
           tag,
         },
-      })
-    })
-  })
-}
+      });
+    });
+  });
+};
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
-  const { createNodeField } = actions
-  fmImagesToRelative(node) // convert image paths for gatsby images
+  const { createNodeField } = actions;
+  fmImagesToRelative(node); // convert image paths for gatsby images
 
   if (node.internal.type === `MarkdownRemark`) {
-    const value = createFilePath({ node, getNode })
+    const value = createFilePath({ node, getNode });
     createNodeField({
       name: `slug`,
       node,
       value,
-    })
+    });
   }
-}
+};
 
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
@@ -117,6 +117,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       lastImage: File @fileByRelativePath
       title: String
       description: String
+      descriptionprojects: String
       client: String
       centeredFirstImage: Boolean
       centeredFirstImageMobile: Boolean
@@ -127,6 +128,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       contactData: [ContactData]
       socialLinks: [SocialLinks]
       embeddedVideo: String
+      blockSearch: Boolean
     }
 
     type AdditionalData {

--- a/src/components/Seo.js
+++ b/src/components/Seo.js
@@ -95,6 +95,15 @@ export default function Seo(props) {
       content: props.keywords,
     });
   }
+  //if site should not be indexed, add label
+  const blockSearch = props.blockSearch ?? false;
+  //console.log("block in search:", title, blockSearch);
+  if (blockSearch) {
+    metas.push({
+      name: "robots",
+      content: "noindex",
+    });
+  }
   return (
     <Helmet>
       <html lang="en" />

--- a/src/pages/contact/index.md
+++ b/src/pages/contact/index.md
@@ -4,6 +4,7 @@ path: /contact
 title: contact
 description: " "
 contactData: []
+blockSearch: false
 socialLinks:
   - title: mail
     name: hello@clackstudio.com

--- a/src/pages/dynamic-pages/data-policy.md
+++ b/src/pages/dynamic-pages/data-policy.md
@@ -5,6 +5,7 @@ description: At www.clack-studio.de, accessible from www.clack-studio.de, one of
   our main priorities is the privacy of our visitors. This Privacy Policy
   document contains types of information that is collected and recorded by
   www.clack-studio.de and how we use it.
+blockSearch: true
 ---
 \
 At www.clackstudio.com, accessible from www.clackstudio.com, one of our main priorities is the privacy of our visitors. This Privacy Policy document contains types of information that is collected and recorded by www.clack-studio.de and how we use it.

--- a/src/pages/imprint/index.md
+++ b/src/pages/imprint/index.md
@@ -3,6 +3,7 @@ templateKey: about-page
 path: /imprint
 title: imprint
 description: Clack Studio GbR
+blockSearch: true
 ---
 Clack Studio GbR \
 \

--- a/src/templates/about-page.js
+++ b/src/templates/about-page.js
@@ -14,12 +14,17 @@ export const AboutPageTemplate = ({
   content,
   contentComponent,
   description,
+  blockSearch,
 }) => {
   const PageContent = contentComponent || Content;
 
   return (
     <SectionTemplate className="single-page-wrapper">
-      <Seo title={title} description={description}></Seo>
+      <Seo
+        title={title}
+        description={description}
+        blockSearch={blockSearch}
+      ></Seo>
       <div className="columns fill-container">
         <div className="column is-flex fill-container">
           <div
@@ -46,11 +51,11 @@ AboutPageTemplate.propTypes = {
   content: PropTypes.string,
   contentComponent: PropTypes.func,
   description: PropTypes.string,
+  blockSearch: PropTypes.bool,
 };
 
 const AboutPage = ({ data, location }) => {
   const { markdownRemark: post } = data;
-
   return (
     <Layout location={location}>
       <AboutPageTemplate
@@ -58,6 +63,7 @@ const AboutPage = ({ data, location }) => {
         title={post.frontmatter.title}
         content={post.html}
         description={post.frontmatter.description}
+        blockSearch={post.frontmatter.blockSearch ?? false}
       />
     </Layout>
   );
@@ -76,6 +82,7 @@ export const aboutPageQuery = graphql`
       frontmatter {
         title
         description
+        blockSearch
       }
     }
   }

--- a/src/templates/contact-page.js
+++ b/src/templates/contact-page.js
@@ -15,11 +15,16 @@ export const ContactPageTemplate = ({
   contentComponent,
   socialLinks,
   contactData,
+  blockSearch,
 }) => {
   // const PageContent = contentComponent || Content;
   return (
     <SectionTemplate className="single-page-wrapper">
-      <Seo title={"contact"} description={description}></Seo>
+      <Seo
+        title={title}
+        description={description}
+        blockSearch={blockSearch}
+      ></Seo>
       <div className="columns fill-container">
         <div className="column fill-container fill-complete-height">
           <div className="is-12 is-flex is-flex-direction-column is-justify-content-flex-end fill-container bigger-font">
@@ -59,7 +64,9 @@ export const ContactPageTemplate = ({
 ContactPageTemplate.propTypes = {
   title: PropTypes.string.isRequired,
   content: PropTypes.string,
+  description: PropTypes.string,
   contentComponent: PropTypes.func,
+  blockSearch: PropTypes.bool,
 };
 
 const ContactPage = ({ data, location }) => {
@@ -73,6 +80,7 @@ const ContactPage = ({ data, location }) => {
         content={post.html}
         socialLinks={post.frontmatter.socialLinks}
         contactData={post.frontmatter.contactData}
+        blockSearch={post.frontmatter.blockSearch}
       />
     </Layout>
   );
@@ -91,6 +99,7 @@ export const contactPageQuery = graphql`
       frontmatter {
         title
         description
+        blockSearch
         contactData {
           title
           data

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -44,7 +44,7 @@ collections:
               { label: Title, name: title, widget: string },
               { label: Data, name: data, widget: string }
            ]
-        }
+        } 
       - {
             label: Section,
             name: section,
@@ -84,7 +84,7 @@ collections:
               default: "about-page",
             }
           - { label: "Title", name: "title", widget: "string" }
-          - { label: "SEO Description About Page", name: "description", widget: "string", default: "contact via mail, phone or instagram" }
+          - { label: "SEO Description About Page", name: "description", widget: "string", default: "clack studio is a berlin based creative agency founded by a female friends duo in 2021" }
           - { label: "SEO Description Projects Page", name: "descriptionprojects", widget: "string", default: "contact via mail, phone or instagram" }
           - { label: "Body", name: "body", required: false, widget: "markdown" }
       - file: "src/pages/imprint/index.md"
@@ -99,6 +99,7 @@ collections:
             }
           - { label: "Title", name: "title", widget: "string" }
           - { label: "SEO Description", name: "description", widget: "string", default: "Clack Studio GbR Vertreten durch: Hélène Marie Camille Mohrbutter & Mana Zarindast" }
+          - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: if this box is checked, the page and the content of the site can not be accessed with google search }
           - { label: "Body", name: "body", required: false, widget: "markdown" }
       - file: "src/pages/contact/index.md"
         label: "Contact"
@@ -111,7 +112,8 @@ collections:
               default: "contact-page",
             }
           - { label: "Title", name: "title", widget: "string" }
-          - { label: "SEO Description", name: "description", widget: "string", default: "clack studio is a berlin based creative agency founded by a female friends duo in 2021" }
+          - { label: "SEO Description", name: "description", widget: "string", default: "contact via mail, phone or instagram" }
+          - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: if this box is checked, the page and the content of the site can not be accessed with google search }
           - { label: "Body", name: "body", required: false, widget: "markdown" }
           - {
               label: Contact Data,
@@ -149,4 +151,5 @@ collections:
           default: "about-page",
         }
       - { label: "Title", name: "title", widget: "string" }
+      - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: if this box is checked, the page and the content of the site can not be accessed with google search }
       - { label: "Body", name: "body", required: false, widget: "markdown" }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -99,7 +99,7 @@ collections:
             }
           - { label: "Title", name: "title", widget: "string" }
           - { label: "SEO Description", name: "description", widget: "string", default: "Clack Studio GbR Vertreten durch: Hélène Marie Camille Mohrbutter & Mana Zarindast" }
-          - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: if this box is checked, the page and the content of the site can not be accessed with google search }
+          - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: hide content from search results }
           - { label: "Body", name: "body", required: false, widget: "markdown" }
       - file: "src/pages/contact/index.md"
         label: "Contact"
@@ -113,7 +113,7 @@ collections:
             }
           - { label: "Title", name: "title", widget: "string" }
           - { label: "SEO Description", name: "description", widget: "string", default: "contact via mail, phone or instagram" }
-          - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: if this box is checked, the page and the content of the site can not be accessed with google search }
+          - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: hide content from search results }
           - { label: "Body", name: "body", required: false, widget: "markdown" }
           - {
               label: Contact Data,
@@ -151,5 +151,5 @@ collections:
           default: "about-page",
         }
       - { label: "Title", name: "title", widget: "string" }
-      - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: if this box is checked, the page and the content of the site can not be accessed with google search }
+      - { label: "Block in Google search", name: "blockSearch", widget: "boolean", default: false, required: false, hint: hide content from search results }
       - { label: "Body", name: "body", required: false, widget: "markdown" }


### PR DESCRIPTION
- add CMS option to "block from google search", which adds a "noindex" meta tag to the page
- this option is only available for the contact, imprint, data policy and dynamic pages, so that the other pages are not accidentally blocked